### PR TITLE
Fixed issue with missing display resolution

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,6 +189,10 @@ func fetchDisplays() ([]display, error) {
 			}
 			return false
 		})
+		if len(vals) < 4 {
+			// no resolution? ignore
+			continue
+		}
 		m.axis.x, _ = strconv.Atoi(vals[0])
 		m.axis.y, _ = strconv.Atoi(vals[1])
 		m.offset.x, _ = strconv.Atoi(vals[2])
@@ -197,6 +201,7 @@ func fetchDisplays() ([]display, error) {
 		displays = append(displays, m)
 	}
 
+	log.Println("Displays found:", displays)
 	return displays, nil
 }
 


### PR DESCRIPTION
- under some circumstances xrandr returns no display resolution for a connected display
- this case is manually handled, such a display will be ignored
- added a log statement whenever the list of displays is updated